### PR TITLE
Fix: Prevent "width greater than radius" error in Pygame circle drawing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,27 @@
 The Game
 =============
 
+The **Fourier Series Visualization Activity** is an interactive tool that helps users understand and explore the concepts of Fourier series through dynamic visual representations. By manipulating various parameters, users can gain insights into how complex waveforms are constructed from simple sinusoidal functions.
 
+**Features and Gameplay:**
+- **Circle Adjustment:**  
+  Users can increase or decrease the number of circles displayed in the visualization. This feature corresponds to the accuracy of the Fourier series representation. More circles lead to a more detailed and accurate approximation of the target waveform, while fewer circles provide a simplified view.
+
+- **Frequency Control:**  
+  The activity allows users to adjust the frequency of the displayed waves. Increasing the frequency results in more oscillations within the same time interval, illustrating how frequency affects the shape of the waveform. Conversely, decreasing the frequency results in fewer oscillations, offering a clearer perspective on the fundamental characteristics of the signal.
+
+- **Real-Time Visualization:**  
+  As users manipulate the number of circles and the frequency, the visualization updates in real-time. This immediate feedback enhances understanding by demonstrating how changes in parameters impact the Fourier series and the resulting waveforms.
+
+Through this activity, users can explore the fundamental principles of Fourier series, gaining a deeper appreciation for how complex signals can be represented as a sum of simpler sinusoidal components. This hands-on approach is beneficial for learners of all ages, making the concepts of signal processing, acoustics, and other applications more accessible.
+
+
+![Image](https://github.com/user-attachments/assets/9e92a297-c63f-4175-a780-5aa2b24dc260)
 
 How to run
 ===========
 
-River Crossing can be run on the Sugar desktop.
+Fourier Series Visulaisation can be run on the Sugar desktop.
 
 * [How to Get Sugar on sugarlabs.org](https://sugarlabs.org/)
 

--- a/views/simulation.py
+++ b/views/simulation.py
@@ -123,12 +123,13 @@ def view(game):
             y += int(MAX_RADIUS * (4 / (n * pi) * sin(n * -step)))
 
             rad = int(sqrt((prev_x - x) ** 2 + (prev_y - y) ** 2))
+            safe_rad = max(rad, STROKE_WIDTH + 1)
 
             clr = CIRCLE_COLORS[i % len(CIRCLE_COLORS)]
 
             pygame.draw.line(screen, CIRCLE_COLOR, (prev_x, prev_y), (x, y), 1)
 
-            pygame.draw.circle(screen, CIRCLE_COLOR, (prev_x, prev_y), rad, STROKE_WIDTH + 1)
+            pygame.draw.circle(screen, CIRCLE_COLOR, (prev_x, prev_y), safe_rad, STROKE_WIDTH + 1)
             pygame.draw.circle(screen, CIRCLE_COLOR, (prev_x, prev_y), rad + 1, STROKE_WIDTH)
             pygame.draw.circle(screen, clr, (prev_x, prev_y), rad, STROKE_WIDTH)
 


### PR DESCRIPTION
Fix ValueError: width greater than radius in circle drawing

- Clamped the computed circle radius (`rad`) to be at least as large as the stroke width (`STROKE_WIDTH + 1`).
- Prevents `ValueError: width greater than radius` when the computed radius is too small.
- Ensures smooth rendering of circles without crashes when reducing circle size.

Error:-
![ferror](https://github.com/user-attachments/assets/2d7df04e-3d47-4501-877d-ecb44fba080f)

